### PR TITLE
Add libpq to overlays (to fix postgres crash upon project load)

### DIFF
--- a/vcpkg-overlay/ports/liblzma/add_support_ios.patch
+++ b/vcpkg-overlay/ports/liblzma/add_support_ios.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 52439b3..0b5e371 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -574,6 +574,7 @@ if(HAVE_GETOPT_LONG)
+ 
+     install(TARGETS xzdec
+             RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
+                     COMPONENT xzdec)
+ 
+     if(UNIX)
+@@ -701,6 +702,7 @@ if(NOT MSVC AND HAVE_GETOPT_LONG)
+ 
+     install(TARGETS xz
+             RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
+                     COMPONENT xz)
+ 
+     if(UNIX)

--- a/vcpkg-overlay/ports/liblzma/fix_config_include.patch
+++ b/vcpkg-overlay/ports/liblzma/fix_config_include.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 34c6aca00..7b3708ab2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -413,6 +413,7 @@ if(WIN32)
+     if(BUILD_SHARED_LIBS)
+         # Add the Windows resource file for liblzma.dll.
+         target_sources(liblzma PRIVATE src/liblzma/liblzma_w32res.rc)
++        target_include_directories(liblzma PRIVATE windows/vs2019)
+ 
+         set_target_properties(liblzma PROPERTIES
+             LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/common/common_w32res.rc"

--- a/vcpkg-overlay/ports/liblzma/portfile.cmake
+++ b/vcpkg-overlay/ports/liblzma/portfile.cmake
@@ -1,0 +1,86 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bminor/xz
+    REF "v${VERSION}"
+    SHA512 c28461123562564e030f3f733f078bc4c840e87598d9f4b718d4bca639120d8133f969c45d7bdc62f33f081d789ec0f14a1791fb7da18515682bfe3c0c7362e0
+    HEAD_REF master
+    PATCHES
+        fix_config_include.patch
+        win_output_name.patch # Fix output name on Windows. Autotool build does not generate lib prefixed libraries on windows. 
+        add_support_ios.patch # add install bundle info for support ios 
+        build-tools.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools BUILD_TOOLS
+)
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "wasm32")
+    set(WASM_OPTIONS -DCMAKE_C_BYTE_ORDER=LITTLE_ENDIAN -DCMAKE_CXX_BYTE_ORDER=LITTLE_ENDIAN)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        ${WASM_OPTIONS}
+        -DBUILD_TESTING=OFF
+        -DCREATE_XZ_SYMLINKS=OFF
+        -DCREATE_LZMA_SYMLINKS=OFF
+        -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=   # using flags from (vcpkg) toolchain
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
+        CREATE_XZ_SYMLINKS
+        CREATE_LZMA_SYMLINKS
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+set(exec_prefix "\${prefix}")
+set(libdir "\${prefix}/lib")
+set(includedir "\${prefix}/include")
+set(PACKAGE_URL https://tukaani.org/xz/)
+set(PACKAGE_VERSION 5.4.3)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    set(PTHREAD_CFLAGS -pthread)
+endif()
+set(prefix "${CURRENT_INSTALLED_DIR}")
+configure_file("${SOURCE_PATH}/src/liblzma/liblzma.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/liblzma.pc" @ONLY)
+if (NOT VCPKG_BUILD_TYPE)
+  set(prefix "${CURRENT_INSTALLED_DIR}/debug")
+  configure_file("${SOURCE_PATH}/src/liblzma/liblzma.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/liblzma.pc" @ONLY)
+endif()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/liblzma)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/lzma.h" "defined(LZMA_API_STATIC)" "1")
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/lzma.h" "defined(LZMA_API_STATIC)" "0")
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/man"
+)
+
+set(TOOLS xz xzdec)
+foreach(_tool IN LISTS TOOLS)
+    if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/bin/${_tool}${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+        list(REMOVE_ITEM TOOLS ${_tool})
+    endif()
+endforeach()
+if(TOOLS)
+    vcpkg_copy_tools(TOOL_NAMES ${TOOLS} AUTO_CLEAN)
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/vcpkg-overlay/ports/liblzma/usage
+++ b/vcpkg-overlay/ports/liblzma/usage
@@ -1,0 +1,9 @@
+liblzma is compatible with built-in CMake targets:
+
+    find_package(LibLZMA REQUIRED)
+    target_link_libraries(main PRIVATE LibLZMA::LibLZMA)
+
+liblzma provides CMake targets:
+
+    find_package(liblzma CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE liblzma::liblzma)

--- a/vcpkg-overlay/ports/liblzma/vcpkg-cmake-wrapper.cmake
+++ b/vcpkg-overlay/ports/liblzma/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,64 @@
+cmake_policy(PUSH)
+cmake_policy(SET CMP0012 NEW)
+cmake_policy(SET CMP0057 NEW)
+set(z_vcpkg_liblzma_fixup_needed 0)
+if(NOT "CONFIG" IN_LIST ARGS AND NOT "NO_MODULE" IN_LIST ARGS AND NOT CMAKE_DISABLE_FIND_PACKAGE_LibLZMA)
+    get_filename_component(z_vcpkg_liblzma_prefix "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+    get_filename_component(z_vcpkg_liblzma_prefix "${z_vcpkg_liblzma_prefix}" DIRECTORY)
+    find_path(LIBLZMA_INCLUDE_DIR NAMES lzma.h PATHS "${z_vcpkg_liblzma_prefix}/include" NO_DEFAULT_PATH)
+    # liblzma doesn't use a debug postfix, but FindLibLZMA.cmake expects it 
+    find_library(LIBLZMA_LIBRARY_RELEASE NAMES lzma PATHS "${z_vcpkg_liblzma_prefix}/lib" NO_DEFAULT_PATH)
+    find_library(LIBLZMA_LIBRARY_DEBUG NAMES lzma PATHS "${z_vcpkg_liblzma_prefix}/debug/lib" NO_DEFAULT_PATH)
+    unset(z_vcpkg_liblzma_prefix)
+    if(CMAKE_VERSION VERSION_LESS 3.16)
+        # Older versions of FindLibLZMA.cmake need a single lib in LIBLZMA_LIBRARY.
+        set(z_vcpkg_liblzma_fixup_needed 1)
+        set(LIBLZMA_LIBRARY "${LIBLZMA_LIBRARY_RELEASE}" CACHE INTERNAL "")
+    elseif(NOT TARGET LibLZMA::LibLZMA)
+        set(z_vcpkg_liblzma_fixup_needed 1)
+    endif()
+    # Known values, and required. Skip expensive tests.
+    set(LIBLZMA_HAS_AUTO_DECODER 1 CACHE INTERNAL "")
+    set(LIBLZMA_HAS_EASY_ENCODER 1 CACHE INTERNAL "")
+    set(LIBLZMA_HAS_LZMA_PRESET 1 CACHE INTERNAL "")
+endif()
+
+_find_package(${ARGS})
+
+if(z_vcpkg_liblzma_fixup_needed)
+    include(SelectLibraryConfigurations)
+    select_library_configurations(LIBLZMA)
+    if(NOT TARGET LibLZMA::LibLZMA)
+        # Backfill LibLZMA::LibLZMA to versions of cmake before 3.14
+        add_library(LibLZMA::LibLZMA UNKNOWN IMPORTED)
+        if(DEFINED LIBLZMA_INCLUDE_DIRS)
+            set_target_properties(LibLZMA::LibLZMA PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${LIBLZMA_INCLUDE_DIRS}")
+        endif()
+        set_property(TARGET LibLZMA::LibLZMA APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS RELEASE)
+        set_target_properties(LibLZMA::LibLZMA PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "C"
+            IMPORTED_LOCATION_RELEASE "${LIBLZMA_LIBRARY_RELEASE}")
+        if(EXISTS "${LIBLZMA_LIBRARY}")
+            set_target_properties(LibLZMA::LibLZMA PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${LIBLZMA_LIBRARY}")
+        endif()
+    endif()
+    if(LIBLZMA_LIBRARY_DEBUG)
+        # Backfill debug variant to versions of cmake before 3.16
+        set_property(TARGET LibLZMA::LibLZMA APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+        set_target_properties(LibLZMA::LibLZMA PROPERTIES IMPORTED_LOCATION_DEBUG "${LIBLZMA_LIBRARY_DEBUG}")
+    endif()
+endif()
+if(LIBLZMA_LIBRARIES AND NOT "Threads::Threads" IN_LIST LIBLZMA_LIBRARIES)
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+    find_package(Threads)
+    list(APPEND LIBLZMA_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    if(TARGET LibLZMA::LibLZMA)
+        set_property(TARGET LibLZMA::LibLZMA APPEND PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads)
+    endif()
+endif()
+unset(z_vcpkg_liblzma_fixup_needed)
+cmake_policy(POP)

--- a/vcpkg-overlay/ports/liblzma/vcpkg.json
+++ b/vcpkg-overlay/ports/liblzma/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "liblzma",
+  "version": "5.4.4",
+  "description": "Compression library with an API similar to that of zlib.",
+  "homepage": "https://tukaani.org/xz/",
+  "license": null,
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tools": {
+      "description": "Build tools",
+      "supports": "!windows, mingw"
+    }
+  }
+}

--- a/vcpkg-overlay/ports/liblzma/win_output_name.patch
+++ b/vcpkg-overlay/ports/liblzma/win_output_name.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0c6d4b7..62a824a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -868,8 +868,11 @@ set_target_properties(liblzma PROPERTIES
+ 
+     # It's liblzma.so or liblzma.dll, not libliblzma.so or lzma.dll.
+     # Avoid the name lzma.dll because it would conflict with LZMA SDK.
+-    PREFIX ""
++    OUTPUT_NAME lzma
+ )
++if(WIN32 AND NOT MINGW)
++    set_target_properties(liblzma PROPERTIES RUNTIME_OUTPUT_NAME liblzma)
++endif()
+ 
+ # Create liblzma-config-version.cmake.
+ #

--- a/vcpkg-overlay/ports/libpq/Makefile
+++ b/vcpkg-overlay/ports/libpq/Makefile
@@ -1,0 +1,54 @@
+subdir = .
+top_builddir = .
+include src/Makefile.global
+
+ifeq ($(LIBPQ_LIBRARY_TYPE), static)
+LIBPQ_INSTALL_LIBS = install-stlib
+endif
+
+ifeq ($(LIBPQ_LIBRARY_TYPE), shared)
+ifeq ($(LIBPQ_USING_MINGW), yes)
+# The import library name is the same as the static library name
+EXTRA_TARGET = install-lib-static
+endif
+endif
+
+.PHONY: all
+all:
+	$(MAKE) -C src/include
+	$(MAKE) -C src/common
+	$(MAKE) -C src/port
+	$(MAKE) -C src/interfaces/libpq all-$(LIBPQ_LIBRARY_TYPE)-lib
+	$(MAKE) -C src/interfaces/ecpg/include
+	$(MAKE) -C src/interfaces/ecpg/pgtypeslib
+	$(MAKE) -C src/interfaces/ecpg/ecpglib
+	$(MAKE) -C src/interfaces/ecpg/compatlib
+ifeq ($(LIBPQ_ENABLE_TOOLS), yes)
+	$(MAKE) -C src/interfaces/ecpg/preproc
+	$(MAKE) -C src/fe_utils
+	$(MAKE) -C src/bin
+else
+	$(MAKE) -C src/bin/pg_config
+endif
+
+.PHONY: install-stlib
+install-stlib:
+	$(MAKE) -C src/common install -o all
+	rm -f '$(DESTDIR)$(libdir)/libpgcommon_shlib.a'
+	$(MAKE) -C src/port install -o all
+	rm -f '$(DESTDIR)$(libdir)/libpgport_shlib.a'
+
+.PHONY: install
+install: $(LIBPQ_INSTALL_LIBS)
+	$(MAKE) -C src/include install
+	$(MAKE) -C src/interfaces/libpq $(EXTRA_TARGET) install-lib-$(LIBPQ_LIBRARY_TYPE) install-lib-pc install -o all -o install-lib
+	$(MAKE) -C src/interfaces/ecpg/include install
+	$(MAKE) -C src/interfaces/ecpg/pgtypeslib install
+	$(MAKE) -C src/interfaces/ecpg/ecpglib install
+	$(MAKE) -C src/interfaces/ecpg/compatlib install
+ifeq ($(LIBPQ_ENABLE_TOOLS), yes)
+	$(MAKE) -C src/interfaces/ecpg/preproc install
+	$(MAKE) -C src/bin install
+else
+	$(MAKE) -C src/bin/pg_config install
+endif

--- a/vcpkg-overlay/ports/libpq/android/unversioned_so.patch
+++ b/vcpkg-overlay/ports/libpq/android/unversioned_so.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Makefile.shlib b/src/Makefile.shlib
+index f94d59d1c597..8ca51ca03f75 100644
+--- a/src/Makefile.shlib
++++ b/src/Makefile.shlib
+@@ -183,6 +183,11 @@ endif
+ ifeq ($(PORTNAME), linux)
+   LINK.shared		= $(COMPILER) -shared
+   ifdef soname
++    ifneq (,$(findstring linux-android,$(host_os)))
++      # Android uses unversioned shared libraries
++      shlib		= $(shlib_bare)
++      soname		= $(shlib_bare)
++    endif
+     LINK.shared		+= -Wl,-soname,$(soname)
+   endif
+   BUILD.exports		= ( echo '{ global:'; $(AWK) '/^[^\#]/ {printf "%s;\n",$$1}' $<; echo ' local: *; };' ) >$@

--- a/vcpkg-overlay/ports/libpq/libpq.props.in
+++ b/vcpkg-overlay/ports/libpq/libpq.props.in
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) @VCPKG_COMBINED_C_FLAGS_DEBUG@</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>%(AdditionalOptions) @VCPKG_COMBINED_SHARED_LINKER_FLAGS_DEBUG@</AdditionalOptions>
+    </Link>
+    <Lib>
+      <AdditionalOptions>%(AdditionalOptions) @VCPKG_COMBINED_STATIC_LINKER_FLAGS_DEBUG@</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) @VCPKG_COMBINED_C_FLAGS_RELEASE@</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>%(AdditionalOptions) @VCPKG_COMBINED_SHARED_LINKER_FLAGS_RELEASE@</AdditionalOptions>
+    </Link>
+    <Lib>
+      <AdditionalOptions>%(AdditionalOptions) @VCPKG_COMBINED_STATIC_LINKER_FLAGS_RELEASE@</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+</Project>

--- a/vcpkg-overlay/ports/libpq/portfile.cmake
+++ b/vcpkg-overlay/ports/libpq/portfile.cmake
@@ -1,0 +1,160 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://ftp.postgresql.org/pub/source/v${VERSION}/postgresql-${VERSION}.tar.bz2"
+    FILENAME "postgresql-${VERSION}.tar.bz2"
+    SHA512 3194941cc3f1ec86b6cf4f08c6422d268d99890441f8fc9ab87b6a7fd16c990fa230b544308644cbef54e6960c4984e3703752e40930bdc0537b7bfda3ab7ccf
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        unix/installdirs.patch
+        unix/fix-configure.patch
+        unix/single-linkage.patch
+        unix/no-server-tools.patch
+        unix/mingw-install.patch
+        unix/python.patch
+        windows/macro-def.patch
+        windows/win_bison_flex.patch
+        windows/msbuild.patch
+        windows/spin_delay.patch
+        android/unversioned_so.patch
+)
+
+file(GLOB _py3_include_path "${CURRENT_HOST_INSTALLED_DIR}/include/python3*")
+string(REGEX MATCH "python3\\.([0-9]+)" _python_version_tmp "${_py3_include_path}")
+set(PYTHON_VERSION_MINOR "${CMAKE_MATCH_1}")
+
+if("client" IN_LIST FEATURES)
+    set(HAS_TOOLS TRUE)
+else()
+    set(HAS_TOOLS FALSE)
+endif()
+
+set(required_programs PERL)
+if(VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND required_programs BISON FLEX)
+endif()
+foreach(program_name IN LISTS required_programs)
+    # Need to rename win_bison and win_flex to just bison and flex
+    vcpkg_find_acquire_program(${program_name})
+    get_filename_component(program_dir ${${program_name}} DIRECTORY)
+    vcpkg_add_to_path(PREPEND "${program_dir}")
+endforeach()
+
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+if(VCPKG_DETECTED_MSVC)
+    if("nls" IN_LIST FEATURES)
+        vcpkg_acquire_msys(MSYS_ROOT PACKAGES gettext)
+        vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
+    endif()
+    if("xml" IN_LIST FEATURES)
+        x_vcpkg_pkgconfig_get_modules(
+            PREFIX PC_LIBXML2
+            MODULES --msvc-syntax libxml-2.0
+            LIBS
+        )
+        separate_arguments(LIBXML2_LIBS_DEBUG NATIVE_COMMAND "${PC_LIBXML2_LIBS_DEBUG}")
+        separate_arguments(LIBXML2_LIBS_RELEASE NATIVE_COMMAND "${PC_LIBXML2_LIBS_RELEASE}")
+    endif()
+    if("xslt" IN_LIST FEATURES)
+        x_vcpkg_pkgconfig_get_modules(
+            PREFIX PC_LIBXSLT
+            MODULES --msvc-syntax libxslt
+            LIBS
+        )
+        separate_arguments(LIBXSLT_LIBS_DEBUG NATIVE_COMMAND "${PC_LIBXSLT_LIBS_DEBUG}")
+        separate_arguments(LIBXSLT_LIBS_RELEASE NATIVE_COMMAND "${PC_LIBXSLT_LIBS_RELEASE}")
+    endif()
+
+    include("${CMAKE_CURRENT_LIST_DIR}/build-msvc.cmake")
+    if(NOT VCPKG_BUILD_TYPE)
+        build_msvc(DEBUG "${SOURCE_PATH}")
+    endif()
+    build_msvc(RELEASE "${SOURCE_PATH}")
+
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+    endif()
+
+    if(HAS_TOOLS)
+        vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+    else()
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools")
+    endif()
+else()
+    file(COPY "${CMAKE_CURRENT_LIST_DIR}/Makefile" DESTINATION "${SOURCE_PATH}")
+
+    vcpkg_list(SET BUILD_OPTS)
+    foreach(option IN ITEMS icu lz4 nls openssl readline xml xslt zlib zstd)
+        if(option IN_LIST FEATURES)
+            list(APPEND BUILD_OPTS --with-${option})
+        else()
+            list(APPEND BUILD_OPTS --without-${option})
+        endif()
+    endforeach()
+    if("nls" IN_LIST FEATURES)
+        set(ENV{MSGFMT} "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin/msgfmt${VCPKG_HOST_EXECUTABLE_SUFFIX}")
+        if(VCPKG_TARGET_IS_ANDROID)
+            list(APPEND BUILD_OPTS [[LIBS=$LIBS -liconv]])
+        endif()
+    endif()
+    if("python" IN_LIST FEATURES)
+        list(APPEND BUILD_OPTS --with-python=3.${PYTHON_VERSION_MINOR})
+        vcpkg_find_acquire_program(PYTHON3)
+        list(APPEND BUILD_OPTS "PYTHON=${PYTHON3}")
+    endif()
+    if(VCPKG_TARGET_IS_ANDROID) # AND CMAKE_SYSTEM_VERSION LESS 26)
+        list(APPEND BUILD_OPTS ac_cv_header_langinfo_h=no)
+    endif()
+    if(VCPKG_DETECTED_CMAKE_OSX_SYSROOT)
+        list(APPEND BUILD_OPTS "PG_SYSROOT=${VCPKG_DETECTED_CMAKE_OSX_SYSROOT}")
+    endif()
+    vcpkg_configure_make(
+        SOURCE_PATH "${SOURCE_PATH}"
+        COPY_SOURCE
+        AUTOCONFIG
+        ADDITIONAL_MSYS_PACKAGES autoconf-archive
+            DIRECT_PACKAGES
+                "https://mirror.msys2.org/msys/x86_64/tzcode-2023c-1-x86_64.pkg.tar.zst"
+                7550b843964744607f736a7138f10c6cd92489406a1b84ac71d9a9d8aa16bc69048aa1b24e1f49291b010347047008194c334ca9c632e17fa8245e85549e3c7a
+        OPTIONS
+            ${BUILD_OPTS}
+        OPTIONS_DEBUG
+            --enable-debug
+    )
+
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        set(ENV{LIBPQ_LIBRARY_TYPE} shared)
+    else()
+        set(ENV{LIBPQ_LIBRARY_TYPE} static)
+    endif()
+    if(VCPKG_TARGET_IS_MINGW)
+        set(ENV{LIBPQ_USING_MINGW} yes)
+    endif()
+    if(HAS_TOOLS)
+        set(ENV{LIBPQ_ENABLE_TOOLS} yes)
+    endif()
+    vcpkg_install_make()
+
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/postgresql/server/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")
+endif()
+
+vcpkg_fixup_pkgconfig()
+configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/postgresql/vcpkg-cmake-wrapper.cmake" @ONLY)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/doc"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/symbols"
+    "${CURRENT_PACKAGES_DIR}/debug/tools"
+    "${CURRENT_PACKAGES_DIR}/symbols"
+    "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug"
+)
+
+file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")

--- a/vcpkg-overlay/ports/libpq/unix/fix-configure.patch
+++ b/vcpkg-overlay/ports/libpq/unix/fix-configure.patch
@@ -1,0 +1,79 @@
+diff --git a/configure.ac b/configure.ac
+index 7f97248..48ff1a1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -19,7 +19,8 @@ m4_pattern_forbid(^PGAC_)dnl to catch undefined macros
+ 
+ AC_INIT([PostgreSQL], [16.2], [pgsql-bugs@lists.postgresql.org], [], [https://www.postgresql.org/])
+ 
+-m4_if(m4_defn([m4_PACKAGE_VERSION]), [2.69], [], [m4_fatal([Autoconf version 2.69 is required.
++cross_compiling=yes # Avoid conftest loading shared objects
++m4_if(m4_defn([m4_PACKAGE_VERSION]), [2.69], [], [m4_warn([unsupported],[Autoconf version 2.69 is required.
+ Untested combinations of 'autoconf' and PostgreSQL versions are not
+ recommended.  You can remove the check from 'configure.ac' but it is then
+ your responsibility whether the result works or not.])])
+@@ -1311,7 +1312,8 @@ if test "$enable_thread_safety" = yes; then
+ fi
+ 
+ if test "$with_readline" = yes; then
+-  PGAC_CHECK_READLINE
++  PKG_CHECK_MODULES([READLINE], [readline], [HAVE_LIBREADLINE=1], [pgac_cv_check_readline=no])
++  LIBS="$READLINE_LIBS $LIBS"
+   if test x"$pgac_cv_check_readline" = x"no"; then
+     AC_MSG_ERROR([readline library not found
+ If you have readline already installed, see config.log for details on the
+@@ -1321,7 +1323,7 @@ Use --without-readline to disable readline support.])
+ fi
+ 
+ if test "$with_zlib" = yes; then
+-  AC_CHECK_LIB(z, inflate, [],
++  PKG_CHECK_MODULES([ZLIB], [zlib], [LIBS="$ZLIB_LIBS $LIBS"],
+                [AC_MSG_ERROR([zlib library not found
+ If you have zlib already installed, see config.log for details on the
+ failure.  It is possible the compiler isn't looking in the proper directory.
+@@ -1370,6 +1372,9 @@ if test "$with_ssl" = openssl ; then
+   # Minimum required OpenSSL version is 1.0.1
+   AC_DEFINE(OPENSSL_API_COMPAT, [0x10001000L],
+             [Define to the OpenSSL API version in use. This avoids deprecation warnings from newer OpenSSL versions.])
++  PKG_CHECK_MODULES([CRYPTO_new_ex_data], [libcrypto], [LIBS="$CRYPTO_new_ex_data_LIBS $LIBS"], [AC_MSG_ERROR([library 'crypto' is required for OpenSSL])])
++  PKG_CHECK_MODULES([SSL_new], [libssl], [LIBS="$SSL_new_LIBS $LIBS"], [AC_MSG_ERROR([library 'ssl' is required for OpenSSL])])
++  if false ; then
+   if test "$PORTNAME" != "win32"; then
+      AC_CHECK_LIB(crypto, CRYPTO_new_ex_data, [], [AC_MSG_ERROR([library 'crypto' is required for OpenSSL])])
+      AC_CHECK_LIB(ssl,    SSL_new, [], [AC_MSG_ERROR([library 'ssl' is required for OpenSSL])])
+@@ -1377,6 +1382,7 @@ if test "$with_ssl" = openssl ; then
+      AC_SEARCH_LIBS(CRYPTO_new_ex_data, [eay32 crypto], [], [AC_MSG_ERROR([library 'eay32' or 'crypto' is required for OpenSSL])])
+      AC_SEARCH_LIBS(SSL_new, [ssleay32 ssl], [], [AC_MSG_ERROR([library 'ssleay32' or 'ssl' is required for OpenSSL])])
+   fi
++  fi
+   # Functions introduced in OpenSSL 1.0.2. LibreSSL does not have
+   # SSL_CTX_set_cert_cb().
+   AC_CHECK_FUNCS([X509_get_signature_nid SSL_CTX_set_cert_cb])
+@@ -1403,19 +1409,23 @@ if test "$with_pam" = yes ; then
+ fi
+ 
+ if test "$with_libxml" = yes ; then
+-  AC_CHECK_LIB(xml2, xmlSaveToBuffer, [], [AC_MSG_ERROR([library 'xml2' (version >= 2.6.23) is required for XML support])])
++  PKG_CHECK_MODULES([LIBXML2], [libxml-2.0 >= 2.6.23], [AC_DEFINE(HAVE_LIBXML2,1,[Define to 1 if with xml2])], [AC_MSG_ERROR([library 'xml2' (version >= 2.6.23) is required for XML support])])
++  LIBS="$LIBXML2_LIBS $LIBS"
+ fi
+ 
+ if test "$with_libxslt" = yes ; then
+-  AC_CHECK_LIB(xslt, xsltCleanupGlobals, [], [AC_MSG_ERROR([library 'xslt' is required for XSLT support])])
++  PKG_CHECK_MODULES([LIBXSLT], [libxslt], [AC_DEFINE(HAVE_LIBXSLT,1,[Define to 1 if with xslt])], [AC_MSG_ERROR([library 'xslt' is required for XSLT support])])
++  LIBS="$LIBXSLT_LIBS $LIBS"
+ fi
+ 
+ if test "$with_lz4" = yes ; then
+-  AC_CHECK_LIB(lz4, LZ4_compress_default, [], [AC_MSG_ERROR([library 'lz4' is required for LZ4 support])])
++  PKG_CHECK_MODULES([LZ4], [liblz4], [AC_DEFINE(HAVE_LIBLZ4,1,[Define to 1 if with lz4])], [AC_MSG_ERROR([library 'lz4' is required for LZ4 support])])
++  LIBS="$LZ4_LIBS $LIBS"
+ fi
+ 
+ if test "$with_zstd" = yes ; then
+-  AC_CHECK_LIB(zstd, ZSTD_compress, [], [AC_MSG_ERROR([library 'zstd' is required for ZSTD support])])
++  PKG_CHECK_MODULES([ZSTD], [libzstd], [AC_DEFINE(HAVE_LIBZSTD,1,[Define to 1 if with zstd])], [AC_MSG_ERROR([library 'zstd' is required for ZSTD support])])
++  LIBS="$ZSTD_LIBS $LIBS"
+ fi
+ 
+ # Note: We can test for libldap_r only after we know PTHREAD_LIBS;

--- a/vcpkg-overlay/ports/libpq/unix/installdirs.patch
+++ b/vcpkg-overlay/ports/libpq/unix/installdirs.patch
@@ -1,0 +1,48 @@
+diff --git a/src/Makefile.global.in b/src/Makefile.global.in
+index 5dacc4d..a9a797e 100644
+--- a/src/Makefile.global.in
++++ b/src/Makefile.global.in
+@@ -100,14 +100,14 @@ datarootdir := @datarootdir@
+ 
+ bindir := @bindir@
+ 
+-datadir := @datadir@
++datadir := @datadir@/postgresql
+ ifeq "$(findstring pgsql, $(datadir))" ""
+ ifeq "$(findstring postgres, $(datadir))" ""
+ override datadir := $(datadir)/postgresql
+ endif
+ endif
+ 
+-sysconfdir := @sysconfdir@
++sysconfdir := @sysconfdir@/postgresql
+ ifeq "$(findstring pgsql, $(sysconfdir))" ""
+ ifeq "$(findstring postgres, $(sysconfdir))" ""
+ override sysconfdir := $(sysconfdir)/postgresql
+@@ -116,7 +116,7 @@ endif
+ 
+ libdir := @libdir@
+ 
+-pkglibdir = $(libdir)
++pkglibdir = $(libdir)/postgresql
+ ifeq "$(findstring pgsql, $(pkglibdir))" ""
+ ifeq "$(findstring postgres, $(pkglibdir))" ""
+ override pkglibdir := $(pkglibdir)/postgresql
+@@ -125,7 +125,7 @@ endif
+ 
+ includedir := @includedir@
+ 
+-pkgincludedir = $(includedir)
++pkgincludedir = $(includedir)/postgresql
+ ifeq "$(findstring pgsql, $(pkgincludedir))" ""
+ ifeq "$(findstring postgres, $(pkgincludedir))" ""
+ override pkgincludedir := $(pkgincludedir)/postgresql
+@@ -134,7 +134,7 @@ endif
+ 
+ mandir := @mandir@
+ 
+-docdir := @docdir@
++docdir := @docdir@/postgresql
+ ifeq "$(findstring pgsql, $(docdir))" ""
+ ifeq "$(findstring postgres, $(docdir))" ""
+ override docdir := $(docdir)/postgresql

--- a/vcpkg-overlay/ports/libpq/unix/mingw-install.patch
+++ b/vcpkg-overlay/ports/libpq/unix/mingw-install.patch
@@ -1,0 +1,36 @@
+diff --git a/src/Makefile.shlib b/src/Makefile.shlib
+index 16255d7..51e9ed2 100644
+--- a/src/Makefile.shlib
++++ b/src/Makefile.shlib
+@@ -85,7 +85,11 @@ else
+ # Naming convention for dynamically loadable modules
+ shlib		= $(NAME)$(DLSUFFIX)
+ endif
++ifeq ($(PORTNAME)-$(LIBPQ_LIBRARY_TYPE), win32-shared)
++stlib		= lib$(NAME).dll.a
++else
+ stlib		= lib$(NAME).a
++endif
+ 
+ ifndef soname
+ # additional flags for backend modules
+@@ -468,6 +472,9 @@ endif
+ else # no soname
+ 	$(INSTALL_SHLIB) $< '$(DESTDIR)$(pkglibdir)/$(shlib)'
+ endif
++ifeq ($(PORTNAME)-$(LIBPQ_LIBRARY_TYPE), win32-shared)
++	mv '$(DESTDIR)$(libdir)/$(shlib)' '$(DESTDIR)$(libdir)/../bin/$(shlib)'
++endif
+ 
+ 
+ installdirs-lib:
+@@ -476,6 +483,9 @@ ifdef soname
+ else
+ 	$(MKDIR_P) '$(DESTDIR)$(pkglibdir)'
+ endif
++ifeq ($(PORTNAME)-$(LIBPQ_LIBRARY_TYPE), win32-shared)
++	$(MKDIR_P) '$(DESTDIR)$(libdir)/../bin'
++endif
+ 
+ 
+ ##

--- a/vcpkg-overlay/ports/libpq/unix/no-server-tools.patch
+++ b/vcpkg-overlay/ports/libpq/unix/no-server-tools.patch
@@ -1,0 +1,37 @@
+diff --git a/src/bin/Makefile b/src/bin/Makefile
+index 7f9dde9..bc6d835 100644
+--- a/src/bin/Makefile
++++ b/src/bin/Makefile
+@@ -13,29 +13,20 @@ subdir = src/bin
+ top_builddir = ../..
+ include $(top_builddir)/src/Makefile.global
+ 
++.NOTPARALLEL:
++# incl. https://www.postgresql.org/docs/current/reference-client.html
++# excl. https://www.postgresql.org/docs/current/reference-server.html
+ SUBDIRS = \
+-	initdb \
+ 	pg_amcheck \
+-	pg_archivecleanup \
+ 	pg_basebackup \
+-	pg_checksums \
+ 	pg_config \
+-	pg_controldata \
+-	pg_ctl \
+ 	pg_dump \
+-	pg_resetwal \
+-	pg_rewind \
+-	pg_test_fsync \
+-	pg_test_timing \
+-	pg_upgrade \
+ 	pg_verifybackup \
+-	pg_waldump \
+ 	pgbench \
+ 	psql \
+ 	scripts
+ 
+ ifeq ($(PORTNAME), win32)
+-SUBDIRS += pgevent
+ else
+ ALWAYS_SUBDIRS += pgevent
+ endif

--- a/vcpkg-overlay/ports/libpq/unix/python.patch
+++ b/vcpkg-overlay/ports/libpq/unix/python.patch
@@ -1,0 +1,35 @@
+diff --git a/configure.ac b/configure.ac
+index 7f97248992..33b6c84fc4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -891,7 +891,9 @@ AC_SUBST(with_perl)
+ # Optionally build Python modules (PL/Python)
+ #
+ AC_MSG_CHECKING([whether to build Python modules])
+-PGAC_ARG_BOOL(with, python, no, [build Python modules (PL/Python)])
++PGAC_ARG_OPTARG(with, python, [PYTHON_VERSION], [build Python modules (PL/Python)],
++                [],
++                [python_version=$withval])
+ AC_MSG_RESULT([$with_python])
+ AC_SUBST(with_python)
+ 
+@@ -1214,7 +1216,18 @@ fi
+ 
+ if test "$with_python" = yes; then
+   PGAC_PATH_PYTHON
+-  PGAC_CHECK_PYTHON_EMBED_SETUP
++  python_majorversion=3
++  PKG_CHECK_MODULES(PYTHON_EMBED, python-${python_version}-embed)
++  python_includespec="${PYTHON_EMBED_CFLAGS}"
++  python_libdir=[$(echo " ${PYTHON_EMBED_LIBS}" | sed -e 's/\( -L[^ ]*\).*/\1/' -e 's/^.* -L//')]
++  python_libspec="${PYTHON_EMBED_LIBS}"
++  python_additional_libs=""
++  AC_SUBST(python_majorversion)
++  AC_SUBST(python_version)
++  AC_SUBST(python_includespec)
++  AC_SUBST(python_libdir)
++  AC_SUBST(python_libspec)
++  AC_SUBST(python_additional_libs)
+ fi
+ 
+ if test x"$cross_compiling" = x"yes" && test -z "$with_system_tzdata"; then

--- a/vcpkg-overlay/ports/libpq/unix/single-linkage.patch
+++ b/vcpkg-overlay/ports/libpq/unix/single-linkage.patch
@@ -1,0 +1,56 @@
+diff --git a/src/Makefile.shlib b/src/Makefile.shlib
+index 551023c..16255d7 100644
+--- a/src/Makefile.shlib
++++ b/src/Makefile.shlib
+@@ -260,10 +260,14 @@ endif
+ 
+ .PHONY: all-lib all-static-lib all-shared-lib
+ 
++ifndef LIBPQ_LIBRARY_TYPE
+ all-lib: all-shared-lib
+ ifdef soname
+ # no static library when building a dynamically loadable module
+ all-lib: all-static-lib
++endif
++else
++all-lib: all-$(LIBPQ_LIBRARY_TYPE)-lib
+ all-lib: lib$(NAME).pc
+ endif
+ 
+@@ -417,9 +421,13 @@ endif # PORTNAME == cygwin || PORTNAME == win32
+ ##
+ 
+ .PHONY: install-lib install-lib-static install-lib-shared installdirs-lib
++ifndef LIBPQ_LIBRARY_TYPE
+ install-lib: install-lib-shared
+ ifdef soname
+ install-lib: install-lib-static
++endif
++else
++install-lib: install-lib-$(LIBPQ_LIBRARY_TYPE)
+ install-lib: install-lib-pc
+ endif
+ 
+diff --git a/src/interfaces/libpq/Makefile b/src/interfaces/libpq/Makefile
+index 8abdb09..185461e 100644
+--- a/src/interfaces/libpq/Makefile
++++ b/src/interfaces/libpq/Makefile
+@@ -115,6 +115,7 @@ backend_src = $(top_srcdir)/src/backend
+ # Also skip the test on platforms where libpq infrastructure may be provided
+ # by statically-linked libraries, as we can't expect them to honor this
+ # coding rule.
++ifeq ($(LIBPQ_LIBRARY_TYPE), shared)
+ libpq-refs-stamp: $(shlib)
+ ifneq ($(enable_coverage), yes)
+ ifeq (,$(filter aix solaris,$(PORTNAME)))
+@@ -124,6 +125,10 @@ ifeq (,$(filter aix solaris,$(PORTNAME)))
+ endif
+ endif
+ 	touch $@
++else
++.PHONY: libpq-refs-stamp
++libpq-refs-stamp:
++endif
+ 
+ # Make dependencies on pg_config_paths.h visible in all builds.
+ fe-connect.o: fe-connect.c $(top_builddir)/src/port/pg_config_paths.h

--- a/vcpkg-overlay/ports/libpq/usage
+++ b/vcpkg-overlay/ports/libpq/usage
@@ -1,0 +1,4 @@
+The package libpq provides CMake integration:
+
+    find_package(PostgreSQL REQUIRED)
+    target_link_libraries(main PRIVATE PostgreSQL::PostgreSQL)

--- a/vcpkg-overlay/ports/libpq/vcpkg-cmake-wrapper.cmake
+++ b/vcpkg-overlay/ports/libpq/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,72 @@
+# Give the CMake module a little bit of help to find the debug libraries
+find_library(PostgreSQL_LIBRARY_DEBUG
+NAMES pq
+PATHS
+  "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib"
+NO_DEFAULT_PATH
+)
+_find_package(${ARGS})
+if(PostgreSQL_FOUND AND NOT "@VCPKG_TARGET_IS_WINDOWS@")
+    find_library(PostgreSQL_DL_LIBRARY NAMES dl)
+    if(PostgreSQL_DL_LIBRARY)
+        list(APPEND PostgreSQL_LIBRARIES "dl")
+        if(TARGET PostgreSQL::PostgreSQL)
+            set_property(TARGET PostgreSQL::PostgreSQL APPEND PROPERTY INTERFACE_LINK_LIBRARIES "dl")
+        endif()
+    endif()
+endif()
+if(PostgreSQL_FOUND AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+    include(SelectLibraryConfigurations)
+    foreach(LIB_ITEM libpgport libpgcommon pgport pgcommon)
+        find_library(PostgreSQL_${LIB_ITEM}_LIBRARY_RELEASE
+            NAMES ${LIB_ITEM}
+            PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib" NO_DEFAULT_PATH
+        )
+        if(TARGET PostgreSQL::PostgreSQL AND PostgreSQL_${LIB_ITEM}_LIBRARY_RELEASE)
+            set_property(
+                TARGET PostgreSQL::PostgreSQL
+                APPEND PROPERTY INTERFACE_LINK_LIBRARIES "\$<\$<NOT:\$<CONFIG:DEBUG>>:${PostgreSQL_${LIB_ITEM}_LIBRARY_RELEASE}>"
+            )
+        endif()
+        
+        find_library(PostgreSQL_${LIB_ITEM}_LIBRARY_DEBUG
+            NAMES ${LIB_ITEM}
+            PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib" NO_DEFAULT_PATH
+        )
+        if(TARGET PostgreSQL::PostgreSQL AND PostgreSQL_${LIB_ITEM}_LIBRARY_DEBUG)
+            set_property(
+                TARGET PostgreSQL::PostgreSQL
+                APPEND PROPERTY INTERFACE_LINK_LIBRARIES "\$<\$<CONFIG:DEBUG>:${PostgreSQL_${LIB_ITEM}_LIBRARY_DEBUG}>"
+            )
+        endif()
+        
+        if (PostgreSQL_${LIB_ITEM}_LIBRARY_RELEASE OR PostgreSQL_${LIB_ITEM}_LIBRARY_DEBUG)
+            select_library_configurations(PostgreSQL_${LIB_ITEM})
+            list(APPEND PostgreSQL_LIBRARIES ${PostgreSQL_${LIB_ITEM}_LIBRARY})
+        endif()
+    endforeach()
+    if(WIN32)
+        if(TARGET PostgreSQL::PostgreSQL)
+            set_property(TARGET PostgreSQL::PostgreSQL APPEND PROPERTY INTERFACE_LINK_LIBRARIES "Secur32.lib")
+        endif()
+        list(APPEND PostgreSQL_LIBRARIES Secur32.lib)
+    endif()
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0057 NEW)
+    set(Z_VCPKG_PORT_FEATURES "@FEATURES@")
+    if("openssl" IN_LIST Z_VCPKG_PORT_FEATURES)
+        find_package(OpenSSL REQUIRED)
+        if(TARGET PostgreSQL::PostgreSQL)
+            set_property(TARGET PostgreSQL::PostgreSQL APPEND PROPERTY INTERFACE_LINK_LIBRARIES "OpenSSL::SSL")
+        endif()
+        list(APPEND PostgreSQL_LIBRARIES OpenSSL::SSL)
+    endif()
+    if(WIN32)
+        if(TARGET PostgreSQL::PostgreSQL)
+            set_property(TARGET PostgreSQL::PostgreSQL APPEND PROPERTY INTERFACE_LINK_LIBRARIES "Wldap32.lib")
+        endif()
+        list(APPEND PostgreSQL_LIBRARIES Wldap32.lib)
+    endif()
+    unset(Z_VCPKG_PORT_FEATURES)
+    cmake_policy(POP)
+endif()

--- a/vcpkg-overlay/ports/libpq/vcpkg-libs.props.in
+++ b/vcpkg-overlay/ports/libpq/vcpkg-libs.props.in
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <VcpkgIcuLibs>@CURRENT_INSTALLED_DIR@/debug/lib/icuind.lib;@CURRENT_INSTALLED_DIR@/debug/lib/icuucd.lib;@CURRENT_INSTALLED_DIR@/debug/lib/icudtd.lib;</VcpkgIcuLibs>
+    <VcpkgLz4Libs>@CURRENT_INSTALLED_DIR@/debug/lib/lz4d.lib</VcpkgLz4Libs>
+    <VcpkgNlsLibs>@CURRENT_INSTALLED_DIR@/debug/lib/intl.lib;@CURRENT_INSTALLED_DIR@/debug/lib/iconv.lib;@CURRENT_INSTALLED_DIR@/debug/lib/charset.lib</VcpkgNlsLibs>
+    <VcpkgOpensslLibs>@CURRENT_INSTALLED_DIR@/debug/lib/libssl.lib;@CURRENT_INSTALLED_DIR@/debug/lib/libcrypto.lib;crypt32.lib;ws2_32.lib;secur32.lib</VcpkgOpensslLibs>
+    <VcpkgPythonLibs>@CURRENT_INSTALLED_DIR@/debug/lib/python3@PYTHON_VERSION_MINOR@_d.lib</VcpkgPythonLibs>
+    <VcpkgTcl90Libs>@CURRENT_INSTALLED_DIR@/debug/lib/tcl90g.lib</VcpkgTcl90Libs>
+    <VcpkgTcl90sLibs>@CURRENT_INSTALLED_DIR@/debug/lib/tcl90sg.lib</VcpkgTcl90sLibs>
+    <VcpkgTcl90sxLibs>@CURRENT_INSTALLED_DIR@/debug/lib/tcl90sgx.lib</VcpkgTcl90sxLibs>
+    <VcpkgXmlLibs>@LIBXML2_LIBS_DEBUG@</VcpkgXmlLibs>
+    <VcpkgXsltLibs>@LIBXSLT_LIBS_DEBUG@</VcpkgXsltLibs>
+    <VcpkgZlibLibs>@CURRENT_INSTALLED_DIR@/debug/lib/zlibd.lib</VcpkgZlibLibs>
+    <VcpkgZstdLibs>@CURRENT_INSTALLED_DIR@/debug/lib/zstd.lib</VcpkgZstdLibs>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <VcpkgIcuLibs>@CURRENT_INSTALLED_DIR@/lib/icuin.lib;@CURRENT_INSTALLED_DIR@/lib/icuuc.lib;@CURRENT_INSTALLED_DIR@/lib/icudt.lib;</VcpkgIcuLibs>
+    <VcpkgLz4Libs>@CURRENT_INSTALLED_DIR@/lib/lz4.lib</VcpkgLz4Libs>
+    <VcpkgNlsLibs>@CURRENT_INSTALLED_DIR@/lib/intl.lib;@CURRENT_INSTALLED_DIR@/lib/iconv.lib;@CURRENT_INSTALLED_DIR@/lib/charset.lib</VcpkgNlsLibs>
+    <VcpkgOpensslLibs>@CURRENT_INSTALLED_DIR@/lib/libssl.lib;@CURRENT_INSTALLED_DIR@/lib/libcrypto.lib;crypt32.lib;ws2_32.lib;secur32.lib</VcpkgOpensslLibs>
+    <VcpkgPythonLibs>@CURRENT_INSTALLED_DIR@/lib/python3@PYTHON_VERSION_MINOR@.lib</VcpkgPythonLibs>
+    <VcpkgTcl90Libs>@CURRENT_INSTALLED_DIR@/lib/tcl90.lib</VcpkgTcl90Libs>
+    <VcpkgTcl90sLibs>@CURRENT_INSTALLED_DIR@/lib/tcl90s.lib</VcpkgTcl90sLibs>
+    <VcpkgTcl90sxLibs>@CURRENT_INSTALLED_DIR@/lib/tcl90sx.lib</VcpkgTcl90sxLibs>
+    <VcpkgXmlLibs>@LIBXML2_LIBS_RELEASE@</VcpkgXmlLibs>
+    <VcpkgXsltLibs>@LIBXSLT_LIBS_RELEASE@</VcpkgXsltLibs>
+    <VcpkgZlibLibs>@CURRENT_INSTALLED_DIR@/lib/zlib.lib</VcpkgZlibLibs>
+    <VcpkgZstdLibs>@CURRENT_INSTALLED_DIR@/lib/zstd.lib</VcpkgZstdLibs>
+  </PropertyGroup>
+</Project>

--- a/vcpkg-overlay/ports/libpq/vcpkg.json
+++ b/vcpkg-overlay/ports/libpq/vcpkg.json
@@ -1,0 +1,195 @@
+{
+  "name": "libpq",
+  "version": "16.2",
+  "port-version": 1,
+  "description": "The official database access API of postgresql",
+  "homepage": "https://www.postgresql.org/",
+  "license": "PostgreSQL",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "libpq",
+      "default-features": false,
+      "features": [
+        "bonjour"
+      ],
+      "platform": "osx"
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
+    {
+      "name": "vcpkg-pkgconfig-get-modules",
+      "host": true,
+      "platform": "windows & !mingw"
+    }
+  ],
+  "default-features": [
+    "lz4",
+    "openssl",
+    "zlib"
+  ],
+  "features": {
+    "all": {
+      "description": "Build all supported features",
+      "dependencies": [
+        {
+          "name": "libpq",
+          "features": [
+            "client",
+            "icu",
+            "xml",
+            "xslt",
+            "zstd"
+          ]
+        },
+        {
+          "name": "libpq",
+          "features": [
+            "bonjour"
+          ],
+          "platform": "osx"
+        },
+        {
+          "name": "libpq",
+          "features": [
+            "nls"
+          ],
+          "platform": "!osx"
+        },
+        {
+          "name": "libpq",
+          "features": [
+            "readline"
+          ],
+          "platform": "!windows"
+        },
+        {
+          "name": "libpq",
+          "features": [
+            "python"
+          ],
+          "platform": "!android & !mingw"
+        },
+        {
+          "name": "libpq",
+          "features": [
+            "tcl"
+          ],
+          "platform": "windows & !mingw & !arm"
+        }
+      ]
+    },
+    "bonjour": {
+      "description": "Build with Bonjour support",
+      "supports": "osx"
+    },
+    "client": {
+      "description": "Build all client tools and libraries"
+    },
+    "icu": {
+      "description": "Build with support for the ICU library",
+      "dependencies": [
+        "icu"
+      ]
+    },
+    "lz4": {
+      "description": "Use lz4",
+      "dependencies": [
+        "lz4"
+      ]
+    },
+    "nls": {
+      "description": "Native Language Support",
+      "supports": "!osx",
+      "dependencies": [
+        "gettext",
+        {
+          "name": "gettext",
+          "host": true,
+          "features": [
+            "tools"
+          ],
+          "platform": "!windows, mingw"
+        }
+      ]
+    },
+    "openssl": {
+      "description": "support for encrypted client connections and random number generation on platforms that do not have \"/dev/urandom\" (except windows)",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "python": {
+      "$supports": "!(windows & (static | mingw))",
+      "description": "build the PL/Python server programming language",
+      "dependencies": [
+        {
+          "name": "libpq",
+          "default-features": false,
+          "features": [
+            "client"
+          ]
+        },
+        "python3"
+      ]
+    },
+    "readline": {
+      "description": "Use readline",
+      "supports": "!windows, mingw",
+      "dependencies": [
+        "readline"
+      ]
+    },
+    "tcl": {
+      "$supports": "!(windows & (static | mingw))",
+      "description": "build the PL/Tcl procedural language",
+      "supports": "windows & !mingw",
+      "dependencies": [
+        {
+          "name": "libpq",
+          "default-features": false,
+          "features": [
+            "client"
+          ]
+        },
+        "tcl"
+      ]
+    },
+    "xml": {
+      "description": "Build with libxml",
+      "dependencies": [
+        {
+          "name": "libxml2",
+          "default-features": false
+        }
+      ]
+    },
+    "xslt": {
+      "description": "Build with libxslt",
+      "dependencies": [
+        {
+          "name": "libpq",
+          "default-features": false,
+          "features": [
+            "xml"
+          ]
+        },
+        "libxslt"
+      ]
+    },
+    "zlib": {
+      "description": "Use zlib",
+      "dependencies": [
+        "zlib"
+      ]
+    },
+    "zstd": {
+      "description": "Use zstd",
+      "dependencies": [
+        "zstd"
+      ]
+    }
+  }
+}

--- a/vcpkg-overlay/ports/libpq/windows/macro-def.patch
+++ b/vcpkg-overlay/ports/libpq/windows/macro-def.patch
@@ -1,0 +1,18 @@
+diff --git a/src/include/common/checksum_helper.h b/src/include/common/checksum_helper.h
+index cac7570ea..d0ca1243c 100644
+--- a/src/include/common/checksum_helper.h
++++ b/src/include/common/checksum_helper.h
+@@ -33,7 +28,13 @@
+  */
+ typedef enum pg_checksum_type
+ {
++#pragma push_macro("CHECKSUM_TYPE_NONE")
++#ifdef CHECKSUM_TYPE_NONE
++// winioctl.h defines CHECKSUM_TYPE_NONE to 0 as a macro. 
++#undef CHECKSUM_TYPE_NONE
++#endif
+ 	CHECKSUM_TYPE_NONE,
++#pragma pop_macro("CHECKSUM_TYPE_NONE")
+ 	CHECKSUM_TYPE_CRC32C,
+ 	CHECKSUM_TYPE_SHA224,
+ 	CHECKSUM_TYPE_SHA256,

--- a/vcpkg-overlay/ports/libpq/windows/msbuild.patch
+++ b/vcpkg-overlay/ports/libpq/windows/msbuild.patch
@@ -1,0 +1,398 @@
+diff --git a/src/tools/msvc/Install.pm b/src/tools/msvc/Install.pm
+index 05548d7..097db91 100644
+--- a/src/tools/msvc/Install.pm
++++ b/src/tools/msvc/Install.pm
+@@ -53,6 +53,11 @@ sub Install
+ 	my $target = shift;
+ 	$insttype = shift;
+ 	$insttype = "all" unless ($insttype);
++	if ($insttype eq 'core')
++	{
++		$insttype = 'client';
++		@client_program_files = ( 'libecpg','libecpg_compat', 'libpgtypes', 'libpq' );
++	}
+ 
+ 	# if called from vcregress, the config will be passed to us
+ 	# so no need to re-include these
+@@ -89,7 +94,7 @@ sub Install
+ 	my $majorver = DetermineMajorVersion();
+ 	print "Installing version $majorver for $conf in $target\n";
+ 
+-	my @client_dirs = ('bin', 'lib', 'share', 'symbols');
++	my @client_dirs = ('bin', 'lib', 'share', 'tools', 'share/libpq', 'tools/libpq');
+ 	my @all_dirs = (
+ 		@client_dirs, 'doc', 'doc/contrib', 'doc/extension', 'share/contrib',
+ 		'share/extension', 'share/timezonesets', 'share/tsearch_data');
+@@ -117,11 +122,11 @@ sub Install
+ 			}
+ 		},
+ 		@top_dir);
+-	CopySetOfFiles('config files', $sample_files, $target . '/share/');
++	CopySetOfFiles('config files', $sample_files, $target . '/share/libpq/');
+ 	CopyFiles(
+ 		'Import libraries',
+ 		$target . '/lib/',
+-		"$conf\\", "postgres\\postgres.lib", "libpgcommon\\libpgcommon.lib",
++		"$conf\\", "libpgcommon\\libpgcommon.lib",
+ 		"libpgport\\libpgport.lib");
+ 	CopyContribFiles($config, $target);
+ 	CopyIncludeFiles($target);
+@@ -293,7 +298,16 @@ sub CopySolutionOutput
+ 		{
+ 			if ($1 == 1)
+ 			{
+-				push(@{ $install_list{'bin'} }, "exe");
++				push(@{ $install_list{'tools\\libpq'} }, "exe");
++			}
++			elsif ($1 == 2)
++			{
++				push(@{ $install_list{'bin'} }, "dll");
++				push(@{ $install_list{'lib'} }, "lib") if $is_sharedlib; # not for plugins
++			}
++			elsif ($is_sharedlib) # forced to static lib by vcpkg triplet
++			{
++				push(@{ $install_list{'lib'} }, "lib");
+ 			}
+ 			elsif ($1 == 2)
+ 			{
+@@ -317,7 +331,16 @@ sub CopySolutionOutput
+ 		{
+ 			if ($1 eq 'Application')
+ 			{
+-				push(@{ $install_list{'bin'} }, "exe");
++				push(@{ $install_list{'tools\\libpq'} }, "exe");
++			}
++			elsif ($1 eq 'DynamicLibrary')
++			{
++				push(@{ $install_list{'bin'} }, "dll");
++				push(@{ $install_list{'lib'} }, "lib") if $is_sharedlib; # not for plugins
++			}
++			elsif ($is_sharedlib) # forced to static lib by vcpkg triplet
++			{
++				push(@{ $install_list{'lib'} }, "lib");
+ 			}
+ 			elsif ($1 eq 'DynamicLibrary')
+ 			{
+@@ -350,7 +373,8 @@ sub CopySolutionOutput
+ 				  || croak "Could not copy $pf.$ext\n";
+ 			}
+ 		}
+-		lcopy("$conf\\$pf\\$pf.pdb", "$target\\symbols\\$pf.pdb")
++		$1 ne 'DynamicLibrary' ||
++		lcopy("$conf\\$pf\\$pf.pdb", "$target\\bin\\$pf.pdb")
+ 		  || croak "Could not copy $pf.pdb\n";
+ 		print ".";
+ 	}
+@@ -453,7 +477,7 @@ sub CopySubdirFiles
+ 		foreach my $f (split /\s+/, $flist)
+ 		{
+ 			lcopy("$subdir/$module/$f.control",
+-				"$target/share/extension/$f.control")
++				"$target/share/libpq/extension/$f.control")
+ 			  || croak("Could not copy file $f.control in contrib $module");
+ 			print '.';
+ 		}
+@@ -471,7 +495,7 @@ sub CopySubdirFiles
+ 		foreach my $f (split /\s+/, $flist)
+ 		{
+ 			lcopy("$subdir/$module/$f",
+-				"$target/share/$moduledir/" . basename($f))
++				"$target/share/libpq/$moduledir/" . basename($f))
+ 			  || croak("Could not copy file $f in contrib $module");
+ 			print '.';
+ 		}
+@@ -486,7 +510,7 @@ sub CopySubdirFiles
+ 		foreach my $f (split /\s+/, $flist)
+ 		{
+ 			lcopy("$subdir/$module/$f",
+-				"$target/share/tsearch_data/" . basename($f))
++				"$target/share/libpq/tsearch_data/" . basename($f))
+ 			  || croak("Could not copy file $f in $subdir $module");
+ 			print '.';
+ 		}
+@@ -549,7 +573,7 @@ sub CopySubdirFiles
+ 		  if ($module eq 'spi');
+ 		foreach my $f (split /\s+/, $flist)
+ 		{
+-			lcopy("$subdir/$module/$f", "$target/doc/$moduledir/$f")
++			lcopy("$subdir/$module/$f", "$target/share/libpq/doc/$moduledir/$f")
+ 			  || croak("Could not copy file $f in contrib $module");
+ 			print '.';
+ 		}
+@@ -675,7 +699,7 @@ sub GenerateNLSFiles
+ 	my $majorver = shift;
+ 
+ 	print "Installing NLS files...";
+-	EnsureDirectories($target, "share/locale");
++	EnsureDirectories($target, "share/libpq/locale");
+ 	my @flist;
+ 	File::Find::find(
+ 		{
+@@ -697,12 +721,12 @@ sub GenerateNLSFiles
+ 			next unless /([^\/]+)\.po/;
+ 			$lang = $1;
+ 
+-			EnsureDirectories($target, "share/locale/$lang",
+-				"share/locale/$lang/LC_MESSAGES");
++			EnsureDirectories($target, "share/libpq/locale/$lang",
++				"share/libpq/locale/$lang/LC_MESSAGES");
+ 			my @args = (
+-				"$nlspath\\bin\\msgfmt",
++				"msgfmt",
+ 				'-o',
+-				"$target\\share\\locale\\$lang\\LC_MESSAGES\\$prgm-$majorver.mo",
++				"$target\\share\\libpq\\locale\\$lang\\LC_MESSAGES\\$prgm-$majorver.mo",
+ 				$_);
+ 			system(@args) && croak("Could not run msgfmt on $dir\\$_");
+ 			print ".";
+diff --git a/src/tools/msvc/MSBuildProject.pm b/src/tools/msvc/MSBuildProject.pm
+index 62fec1f..ecb1b86 100644
+--- a/src/tools/msvc/MSBuildProject.pm
++++ b/src/tools/msvc/MSBuildProject.pm
+@@ -80,14 +80,14 @@ EOF
+ 	print $f <<EOF;
+   </PropertyGroup>
+ EOF
+-
++    my $maybe_dll = $self->{solution}->{options}->{VCPKG_CRT_LINKAGE} eq 'dynamic' ? "DLL" : '';
+ 	$self->WriteItemDefinitionGroup(
+ 		$f, 'Debug',
+ 		{
+ 			defs => "_DEBUG;DEBUG=1",
+ 			opt => 'Disabled',
+ 			strpool => 'false',
+-			runtime => 'MultiThreadedDebugDLL'
++			runtime => 'MultiThreadedDebug' . $maybe_dll
+ 		});
+ 	$self->WriteItemDefinitionGroup(
+ 		$f,
+@@ -96,7 +96,7 @@ EOF
+ 			defs => "",
+ 			opt => 'Full',
+ 			strpool => 'true',
+-			runtime => 'MultiThreadedDLL'
++			runtime => 'MultiThreaded' . $maybe_dll
+ 		});
+ 	return;
+ }
+@@ -266,6 +266,8 @@ sub WriteConfigurationPropertyGroup
+ 	  ($self->{type} eq "exe")
+ 	  ? 'Application'
+ 	  : ($self->{type} eq "dll" ? 'DynamicLibrary' : 'StaticLibrary');
++	if ($self->{solution}->{options}->{VCPKG_LIBRARY_LINKAGE} eq 'static')
++	  { $cfgtype =~ s/DynamicLibrary/StaticLibrary/; }
+ 
+ 	print $f <<EOF;
+   <PropertyGroup Condition="'\$(Configuration)|\$(Platform)'=='$cfgname|$self->{platform}'" Label="Configuration">
+@@ -311,7 +313,9 @@ sub WriteItemDefinitionGroup
+ 	my $libs = $self->GetAdditionalLinkerDependencies($cfgname, ';');
+ 
+ 	my $targetmachine =
+-	  $self->{platform} eq 'Win32' ? 'MachineX86' : 'MachineX64';
++	  'Machine' . uc($self->{platform});
++	$targetmachine =~ s/WIN32/X86/;
++	my $randomizebase = ($self->{platform} =~ /^ARM/) ? 'true' : 'false';
+ 	my $arch = $self->{platform} eq 'Win32' ? 'x86' : 'x86_64';
+ 
+ 	my $includes = join ';', @{ $self->{includes} }, "";
+diff --git a/src/tools/msvc/Mkvcbuild.pm b/src/tools/msvc/Mkvcbuild.pm
+index 9e05eb9..8ac0a5d 100644
+--- a/src/tools/msvc/Mkvcbuild.pm
++++ b/src/tools/msvc/Mkvcbuild.pm
+@@ -125,8 +125,10 @@ sub mkvcbuild
+ 
+ 	if ($vsVersion >= '9.00')
+ 	{
++        if ($solution->{platform} !~ /^ARM/) {
+ 		push(@pgportfiles, 'pg_crc32c_sse42_choose.c');
+ 		push(@pgportfiles, 'pg_crc32c_sse42.c');
++        }
+ 		push(@pgportfiles, 'pg_crc32c_sb8.c');
+ 	}
+ 	else
+@@ -208,6 +210,7 @@ sub mkvcbuild
+ 		'syncrep_gram.y');
+ 	$postgres->AddFiles('src/backend/utils/adt', 'jsonpath_scan.l',
+ 		'jsonpath_gram.y');
++    ($config->{VCPKG_LIBRARY_LINKAGE} eq 'dynamic') &&
+ 	$postgres->AddDefine('BUILDING_DLL');
+ 	$postgres->AddLibrary('secur32.lib');
+ 	$postgres->AddLibrary('ws2_32.lib');
+@@ -252,12 +255,13 @@ sub mkvcbuild
+ 		$pltcl->AddIncludeDir($solution->{options}->{tcl} . '/include');
+ 		$pltcl->AddReference($postgres);
+ 
+-		for my $tclver (qw(86t 86 85 84))
++		my $v = $solution->{options}->{tcl_version};
++		for my $tclver ( ("${v}","${v}s","${v}sx") )
+ 		{
+ 			my $tcllib = $solution->{options}->{tcl} . "/lib/tcl$tclver.lib";
+ 			if (-e $tcllib)
+ 			{
+-				$pltcl->AddLibrary($tcllib);
++				$pltcl->AddLibrary("\$(VcpkgTcl${tclver}Libs)");
+ 				$found = 1;
+ 				last;
+ 			}
+@@ -512,8 +516,7 @@ sub mkvcbuild
+ 		  . "print(str(sys.version_info[0])+str(sys.version_info[1]))";
+ 		my $prefixcmd =
+ 		  qq("$solution->{options}->{python}\\python" -c "$pythonprog");
+-		my $pyout = `$prefixcmd`;
+-		die "Could not query for python version!\n" if $?;
++        my $pyout = "$solution->{options}->{python}\n$solution->{options}->{python_version}";
+ 		my ($pyprefix, $pyver) = split(/\r?\n/, $pyout);
+ 
+ 		# Sometimes (always?) if python is not present, the execution
+@@ -529,8 +532,8 @@ sub mkvcbuild
+ 
+ 		my $plpython = $solution->AddProject('plpython' . $pymajorver,
+ 			'dll', 'PLs', 'src/pl/plpython');
+-		$plpython->AddIncludeDir($pyprefix . '/include');
+-		$plpython->AddLibrary($pyprefix . "/Libs/python$pyver.lib");
++		$plpython->AddIncludeDir($pyprefix . "/include/python$pyver");
++		$plpython->AddLibrary('$(VcpkgPythonLibs)');
+ 		$plpython->AddReference($postgres);
+ 
+ 		# Add transform modules dependent on plpython
+diff --git a/src/tools/msvc/Project.pm b/src/tools/msvc/Project.pm
+index 0507ad0..48caab9 100644
+--- a/src/tools/msvc/Project.pm
++++ b/src/tools/msvc/Project.pm
+@@ -167,6 +167,11 @@ sub AddReference
+ 		}
+ 		$self->AddLibrary(
+ 			"__CFGNAME__/" . $ref->{name} . "/" . $ref->{name} . ".lib");
++
++		if ($self->{solution}->{options}->{VCPKG_LIBRARY_LINKAGE} eq 'static')
++		{
++			map { $self->AddLibrary($_) } @{ $ref->{libraries} };
++		}
+ 	}
+ 	return;
+ }
+diff --git a/src/tools/msvc/Solution.pm b/src/tools/msvc/Solution.pm
+index b6d31c3..27d89fc 100644
+--- a/src/tools/msvc/Solution.pm
++++ b/src/tools/msvc/Solution.pm
+@@ -63,6 +63,11 @@ sub DeterminePlatform
+ 	my $self = shift;
+ 
+ 	if ($^O eq "MSWin32")
++	{
++		$self->{platform} = uc($self->{options}->{VCPKG_TARGET_ARCHITECTURE});
++		$self->{platform} =~ s/^X86$/Win32/;
++	}
++	elsif (0)
+ 	{
+ 		# Examine CL help output to determine if we are in 32 or 64-bit mode.
+ 		my $output = `cl /help 2>&1`;
+@@ -124,6 +129,9 @@ sub copyFile
+ sub GetOpenSSLVersion
+ {
+ 	my $self = shift;
++	if ($self->{options}->{openssl_version} =~ /(\d+)\.(\d+)\.(\d+)/m) {
++		return ($1, $2, $3);
++	}
+ 
+ 	# Attempt to get OpenSSL version and location.  This assumes that
+ 	# openssl.exe is in the specified directory.
+@@ -148,7 +156,7 @@ sub GetOpenSSLVersion
+ sub GenerateFiles
+ {
+ 	my $self = shift;
+-	my $bits = $self->{platform} eq 'Win32' ? 32 : 64;
++	my $bits          = $self->{platform} =~ /64/ ? 64 : 32;
+ 	my $ac_init_found = 0;
+ 	my $package_name;
+ 	my $package_version;
+@@ -440,7 +448,7 @@ sub GenerateFiles
+ 		USE_PAM => undef,
+ 		USE_SLICING_BY_8_CRC32C => undef,
+ 		USE_SSE42_CRC32C => undef,
+-		USE_SSE42_CRC32C_WITH_RUNTIME_CHECK => 1,
++		USE_SSE42_CRC32C_WITH_RUNTIME_CHECK => $self->{platform} =~ /^ARM/ ? undef : 1,
+ 		USE_SYSTEMD => undef,
+ 		USE_SYSV_SEMAPHORES => undef,
+ 		USE_SYSV_SHARED_MEMORY => undef,
+@@ -725,14 +733,14 @@ sub GenerateFiles
+ 		  || confess "Could not open pg_config_paths.h";
+ 		print $o <<EOF;
+ #define PGBINDIR "/bin"
+-#define PGSHAREDIR "/share"
++#define PGSHAREDIR "/share/libpq"
+ #define SYSCONFDIR "/etc"
+ #define INCLUDEDIR "/include"
+ #define PKGINCLUDEDIR "/include"
+ #define INCLUDEDIRSERVER "/include/server"
+ #define LIBDIR "/lib"
+ #define PKGLIBDIR "/lib"
+-#define LOCALEDIR "/share/locale"
++#define LOCALEDIR "/share/libpq/locale"
+ #define DOCDIR "/doc"
+ #define HTMLDIR "/doc"
+ #define MANDIR "/man"
+@@ -957,11 +965,15 @@ sub AddProject
+ 	if ($self->{options}->{zlib})
+ 	{
+ 		$proj->AddIncludeDir($self->{options}->{zlib} . '\include');
+-		$proj->AddLibrary($self->{options}->{zlib} . '\lib\zdll.lib');
++		$proj->AddLibrary('$(VcpkgZlibLibs)');
+ 	}
+ 	if ($self->{options}->{openssl})
+ 	{
+ 		$proj->AddIncludeDir($self->{options}->{openssl} . '\include');
++		$proj->AddLibrary('$(VcpkgOpensslLibs)');
++	}
++	elsif (0)
++	{
+ 		my ($digit1, $digit2, $digit3) = $self->GetOpenSSLVersion();
+ 
+ 		# Starting at version 1.1.0 the OpenSSL installers have
+@@ -1032,7 +1044,7 @@ sub AddProject
+ 	if ($self->{options}->{nls})
+ 	{
+ 		$proj->AddIncludeDir($self->{options}->{nls} . '\include');
+-		$proj->AddLibrary($self->{options}->{nls} . '\lib\libintl.lib');
++		$proj->AddLibrary('$(VcpkgNlsLibs)');
+ 	}
+ 	if ($self->{options}->{gss})
+ 	{
+@@ -1065,6 +1077,10 @@ sub AddProject
+ 	if ($self->{options}->{icu})
+ 	{
+ 		$proj->AddIncludeDir($self->{options}->{icu} . '\include');
++		$proj->AddLibrary('$(VcpkgIcuLibs)');
++	}
++	elsif (0)
++	{
+ 		if ($self->{platform} eq 'Win32')
+ 		{
+ 			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuin.lib');
+@@ -1082,22 +1098,22 @@ sub AddProject
+ 	{
+ 		$proj->AddIncludeDir($self->{options}->{xml} . '\include');
+ 		$proj->AddIncludeDir($self->{options}->{xml} . '\include\libxml2');
+-		$proj->AddLibrary($self->{options}->{xml} . '\lib\libxml2.lib');
++		$proj->AddLibrary('$(VcpkgXmlLibs)');
+ 	}
+ 	if ($self->{options}->{xslt})
+ 	{
+ 		$proj->AddIncludeDir($self->{options}->{xslt} . '\include');
+-		$proj->AddLibrary($self->{options}->{xslt} . '\lib\libxslt.lib');
++		$proj->AddLibrary('$(VcpkgXsltLibs)');
+ 	}
+ 	if ($self->{options}->{lz4})
+ 	{
+ 		$proj->AddIncludeDir($self->{options}->{lz4} . '\include');
+-		$proj->AddLibrary($self->{options}->{lz4} . '\lib\liblz4.lib');
++		$proj->AddLibrary('$(VcpkgLz4Libs)');
+ 	}
+ 	if ($self->{options}->{zstd})
+ 	{
+ 		$proj->AddIncludeDir($self->{options}->{zstd} . '\include');
+-		$proj->AddLibrary($self->{options}->{zstd} . '\lib\libzstd.lib');
++		$proj->AddLibrary('$(VcpkgZstdLibs)');
+ 	}
+ 	if ($self->{options}->{uuid})
+ 	{

--- a/vcpkg-overlay/ports/libpq/windows/spin_delay.patch
+++ b/vcpkg-overlay/ports/libpq/windows/spin_delay.patch
@@ -1,0 +1,24 @@
+diff --git a/src/include/storage/s_lock.h b/src/include/storage/s_lock.h
+index 4d3ffc7..658b1a1 100644
+--- a/src/include/storage/s_lock.h
++++ b/src/include/storage/s_lock.h
+@@ -953,12 +953,18 @@ typedef LONG slock_t;
+ /* If using Visual C++ on Win64, inline assembly is unavailable.
+  * Use a _mm_pause intrinsic instead of rep nop.
+  */
+-#if defined(_WIN64)
++#if defined(_M_X64) && !defined(_M_ARM64EC)
+ static __forceinline void
+ spin_delay(void)
+ {
+ 	_mm_pause();
+ }
++#elif defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
++static __forceinline void
++spin_delay(void)
++{
++	__yield();
++}
+ #else
+ static __forceinline void
+ spin_delay(void)

--- a/vcpkg-overlay/ports/libpq/windows/win_bison_flex.patch
+++ b/vcpkg-overlay/ports/libpq/windows/win_bison_flex.patch
@@ -1,0 +1,42 @@
+diff --git a/src/tools/msvc/pgbison.pl b/src/tools/msvc/pgbison.pl
+index 25df669..373bedd 100644
+--- a/src/tools/msvc/pgbison.pl
++++ b/src/tools/msvc/pgbison.pl
+@@ -13,7 +13,7 @@ use File::Basename;
+ 
+ do './src/tools/msvc/buildenv.pl' if -e 'src/tools/msvc/buildenv.pl';
+ 
+-my ($bisonver) = `bison -V`;                 # grab first line
++my ($bisonver) = `win_bison -V`;    # grab first line
+ $bisonver = (split(/\s+/, $bisonver))[3];    # grab version number
+ 
+ unless ($bisonver ge '2.3')
+@@ -51,5 +51,5 @@ my $headerflag = ($make =~ /^$basetarg:\s+BISONFLAGS\b.*-d/m ? '-d' : '');
+ 
+ my $nodep = $bisonver ge '3.0' ? "-Wno-deprecated" : "";
+ 
+-system("bison $nodep $headerflag $input -o $output");
++system("win_bison $nodep $headerflag $input -o $output");
+ exit $? >> 8;
+diff --git a/src/tools/msvc/pgflex.pl b/src/tools/msvc/pgflex.pl
+index c308a08..0807ce7 100644
+--- a/src/tools/msvc/pgflex.pl
++++ b/src/tools/msvc/pgflex.pl
+@@ -16,7 +16,7 @@ $ENV{CYGWIN} = 'nodosfilewarning';
+ 
+ do './src/tools/msvc/buildenv.pl' if -e 'src/tools/msvc/buildenv.pl';
+ 
+-my ($flexver) = `flex -V`;    # grab first line
++my ($flexver) = `win_flex -V`;    # grab first line
+ $flexver = (split(/\s+/, $flexver))[1];
+ $flexver =~ s/[^0-9.]//g;
+ my @verparts = split(/\./, $flexver);
+@@ -52,7 +52,7 @@ close($mf);
+ my $basetarg = basename($output);
+ my $flexflags = ($make =~ /^$basetarg:\s*FLEXFLAGS\s*=\s*(\S.*)/m ? $1 : '');
+ 
+-system("flex $flexflags -o$output $input");
++system("win_flex $flexflags -o$output $input");
+ if ($? == 0)
+ {
+ 


### PR DESCRIPTION
In our current vcpkg baseline, there is libpq 16.0 and openssl 3.2.1, and they do not work together well: connecting to postgres servers fails (claiming that username was not provided, even if it was) and qgis postgres provider was causing a crash because of that.

This adds libpq 16.2 port (which works fin with openssl 3.2.x) from today's vcpkg (with no changes). Once we move to a newer vcpkg baseline, this port can be safely removed.

Verified in a local build that with libpq 16.2 the crash is gone and postgres connection works.

refs: https://github.com/MerginMaps/mobile/issues/3258

see also: https://github.com/Homebrew/homebrew-core/issues/155651

Also adds lzma port to the overlay because the original download URL is broken for now (https://github.com/microsoft/vcpkg/issues/37839). Hopefully this will get addressed in vcpkg soon and we will be able to remove this port from overlay.