### PR TITLE
feat: support zstd tiff files

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,7 +24,7 @@
         {
             "name": "tiff",
             "default-features": false,
-            "features": ["webp", "zip", "lzma", "jpeg"]
+            "features": ["webp", "zip", "lzma", "jpeg", "zstd"]
         },
         {
             "name": "kdab-openssl",


### PR DESCRIPTION
I am encountering many geotiff files compressed with `zstd`. Would you consider adding `zstd` support?